### PR TITLE
Using WorkflowContextInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "phpmentors/workflower": "~1.0",
+        "phpmentors/workflower": "~1.1@dev",
         "symfony/config": "~2.7",
         "symfony/dependency-injection": "~2.7",
         "symfony/finder": "~2.7",

--- a/src/DependencyInjection/PHPMentorsWorkflowerExtension.php
+++ b/src/DependencyInjection/PHPMentorsWorkflowerExtension.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2015 KUBO Atsuhiro <kubo@iteman.jp>,
+ * Copyright (c) 2015-2016 KUBO Atsuhiro <kubo@iteman.jp>,
  * All rights reserved.
  *
  * This file is part of PHPMentorsWorkflowerBundle.
@@ -75,8 +75,13 @@ class PHPMentorsWorkflowerExtension extends Extension
 
                 $bpmn2WorkflowRepositoryDefinition->addMethodCall('add', array(new Reference($bpmn2FileServiceId)));
 
+                $workflowContextDefinition = new DefinitionDecorator('phpmentors_workflower.workflow_context');
+                $workflowContextDefinition->setArguments(array($workflowContextId, $workflowId));
+                $workflowContextServiceId = 'phpmentors_workflower.workflow_context.'.sha1($workflowContextId.$workflowId);
+                $container->setDefinition($workflowContextServiceId, $workflowContextDefinition);
+
                 $processDefinition = new DefinitionDecorator('phpmentors_workflower.process');
-                $processDefinition->setArguments(array(pathinfo($definitionFile->getFilename(), PATHINFO_FILENAME), new Reference($bpmn2WorkflowRepositoryServiceId)));
+                $processDefinition->setArguments(array(new Reference($workflowContextServiceId), new Reference($bpmn2WorkflowRepositoryServiceId)));
                 $processServiceId = 'phpmentors_workflower.process.'.sha1($workflowContextId.$workflowId);
                 $container->setDefinition($processServiceId, $processDefinition);
             }

--- a/src/Process/WorkflowContext.php
+++ b/src/Process/WorkflowContext.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Copyright (c) 2016 KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Process;
+
+use PHPMentors\Workflower\Process\WorkflowContextInterface;
+
+/**
+ * @since Class available since Release 1.1.0
+ */
+class WorkflowContext implements WorkflowContextInterface
+{
+    /**
+     * @var int|string
+     */
+    private $workflowContextId;
+
+    /**
+     * @var int|string
+     */
+    private $workflowId;
+
+    /**
+     * @param int|string $workflowContextId
+     * @param int|string $workflowId
+     */
+    public function __construct($workflowContextId, $workflowId)
+    {
+        $this->workflowContextId = $workflowContextId;
+        $this->workflowId = $workflowId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getWorkflowId()
+    {
+        return $this->workflowId;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getWorkflowContextId()
+    {
+        return $this->workflowContextId;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,6 +10,7 @@
     <parameter key="phpmentors_workflower.process.class">PHPMentors\Workflower\Process\Process</parameter>
     <parameter key="phpmentors_workflower.security_participant.class">PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipant</parameter>
     <parameter key="phpmentors_workflower.work_item_context.class">PHPMentors\Workflower\Process\WorkItemContext</parameter>
+    <parameter key="phpmentors_workflower.workflow_context.class">PHPMentors\WorkflowerBundle\Process\WorkflowContext</parameter>
     <!-- Configuration parameters -->
   </parameters>
   <services>
@@ -33,5 +34,6 @@
     <service id="phpmentors_workflower.work_item_context" class="%phpmentors_workflower.work_item_context.class%" scope="prototype">
       <argument type="service" id="phpmentors_workflower.participant"/>
     </service>
+    <service id="phpmentors_workflower.workflow_context" class="%phpmentors_workflower.workflow_context.class%" public="false" abstract="true"/>
   </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | BSD-2-Clause

This PR introduces `WorkflowContext` instead of bare workflow ID. `Process::getWorkflowContext()` will return the `WorkflowContext` object for the process.
