### PR TITLE
Service Task support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "phpmentors/workflower": "~1.1",
+        "phpmentors/workflower": "~1.2@dev",
         "symfony/config": "~2.7",
         "symfony/dependency-injection": "~2.7",
         "symfony/finder": "~2.7",

--- a/src/DependencyInjection/Compiler/OperationRunnerPass.php
+++ b/src/DependencyInjection/Compiler/OperationRunnerPass.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @since Class available since Release 1.2.0
+ */
+class OperationRunnerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('phpmentors_workflower.operation_runner') as $serviceId => $tagAttributes) {
+            $class = new \ReflectionClass($container->getParameterBag()->resolveValue($container->getDefinition($serviceId)->getClass()));
+            if (!$class->implementsInterface('PHPMentors\Workflower\Workflow\Operation\OperationRunnerInterface')) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The class "%s" must implement "%s".',
+                    $class->getName(),
+                    'PHPMentors\Workflower\Workflow\Operation\OperationRunnerInterface'
+                ));
+            }
+
+            for ($i = 0; $i < count($tagAttributes); ++$i) {
+                $container->getDefinition('phpmentors_workflower.operation_runner_delegate')->addMethodCall('addOperationRunner', array($serviceId, new Reference($serviceId)));
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/SecurityParticipantAwarePass.php
+++ b/src/DependencyInjection/Compiler/SecurityParticipantAwarePass.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @since Class available since Release 1.2.0
+ */
+class SecurityParticipantAwarePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->findTaggedServiceIds('phpmentors_workflower.security_participant_aware') as $serviceId => $tagAttributes) {
+            $class = new \ReflectionClass($container->getParameterBag()->resolveValue($container->getDefinition($serviceId)->getClass()));
+            if (!$class->implementsInterface('PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipantAwareInterface')) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The class "%s" must implement "%s".',
+                    $class->getName(),
+                    'PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipantAwareInterface'
+                ));
+            }
+
+            for ($i = 0; $i < count($tagAttributes); ++$i) {
+                $container->getDefinition($serviceId)->addMethodCall('setSecurityParticipant', array(new Reference('phpmentors_workflower.security_participant')));
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/PHPMentorsWorkflowerExtension.php
+++ b/src/DependencyInjection/PHPMentorsWorkflowerExtension.php
@@ -81,7 +81,11 @@ class PHPMentorsWorkflowerExtension extends Extension
                 $container->setDefinition($workflowContextServiceId, $workflowContextDefinition);
 
                 $processDefinition = new DefinitionDecorator('phpmentors_workflower.process');
-                $processDefinition->setArguments(array(new Reference($workflowContextServiceId), new Reference($bpmn2WorkflowRepositoryServiceId)));
+                $processDefinition->setArguments(array(
+                    new Reference($workflowContextServiceId),
+                    new Reference($bpmn2WorkflowRepositoryServiceId),
+                    new Reference('phpmentors_workflower.operation_runner_delegate'),
+                ));
                 $processServiceId = 'phpmentors_workflower.process.'.sha1($workflowContextId.$workflowId);
                 $container->setDefinition($processServiceId, $processDefinition);
             }

--- a/src/PHPMentorsWorkflowerBundle.php
+++ b/src/PHPMentorsWorkflowerBundle.php
@@ -13,6 +13,8 @@
 namespace PHPMentors\WorkflowerBundle;
 
 use PHPMentors\WorkflowerBundle\DependencyInjection\Compiler\AlterDefinitionsIntoProcessAwarePass;
+use PHPMentors\WorkflowerBundle\DependencyInjection\Compiler\OperationRunnerPass;
+use PHPMentors\WorkflowerBundle\DependencyInjection\Compiler\SecurityParticipantAwarePass;
 use PHPMentors\WorkflowerBundle\DependencyInjection\PHPMentorsWorkflowerExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,6 +27,8 @@ class PHPMentorsWorkflowerBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AlterDefinitionsIntoProcessAwarePass());
+        $container->addCompilerPass(new OperationRunnerPass());
+        $container->addCompilerPass(new SecurityParticipantAwarePass());
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -26,7 +26,7 @@
     <service id="phpmentors_workflower.participant" alias="phpmentors_workflower.security_participant" public="false"/>
     <service id="phpmentors_workflower.php_workflow_serializer" class="%phpmentors_workflower.php_workflow_serializer.class%" public="false"/>
     <service id="phpmentors_workflower.process" class="%phpmentors_workflower.process.class%" public="false" abstract="true"/>
-    <service id="phpmentors_workflower.security_participant" class="%phpmentors_workflower.security_participant.class%" scope="prototype" public="false">
+    <service id="phpmentors_workflower.security_participant" class="%phpmentors_workflower.security_participant.class%" public="false">
       <argument type="service" id="security.access.role_hierarchy_voter"/>
       <argument type="service" id="security.token_storage"/>
     </service>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,6 +6,7 @@
     <parameter key="phpmentors_workflower.bpmn2_file.class">PHPMentors\Workflower\Definition\Bpmn2File</parameter>
     <parameter key="phpmentors_workflower.bpmn2_workflow_repository.class">PHPMentors\Workflower\Definition\Bpmn2WorkflowRepository</parameter>
     <parameter key="phpmentors_workflower.doctrine_lifecycle_listener.class">PHPMentors\WorkflowerBundle\Persistence\DoctrineLifecycleListener</parameter>
+    <parameter key="phpmentors_workflower.operation_runner_delegate.class">PHPMentors\WorkflowerBundle\Workflow\Operation\OperationRunnerDelegate</parameter>
     <parameter key="phpmentors_workflower.php_workflow_serializer.class">PHPMentors\Workflower\Persistence\PhpWorkflowSerializer</parameter>
     <parameter key="phpmentors_workflower.process.class">PHPMentors\Workflower\Process\Process</parameter>
     <parameter key="phpmentors_workflower.security_participant.class">PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipant</parameter>
@@ -23,6 +24,7 @@
       <tag name="doctrine.event_listener" event="preUpdate"/>
       <tag name="doctrine.event_listener" event="postLoad"/>
     </service>
+    <service id="phpmentors_workflower.operation_runner_delegate" class="%phpmentors_workflower.operation_runner_delegate.class%" public="false"/>
     <service id="phpmentors_workflower.participant" alias="phpmentors_workflower.security_participant" public="false"/>
     <service id="phpmentors_workflower.php_workflow_serializer" class="%phpmentors_workflower.php_workflow_serializer.class%" public="false"/>
     <service id="phpmentors_workflower.process" class="%phpmentors_workflower.process.class%" public="false" abstract="true"/>

--- a/src/Workflow/Operation/OperationRunnerDelegate.php
+++ b/src/Workflow/Operation/OperationRunnerDelegate.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Operation;
+
+use PHPMentors\Workflower\Workflow\Operation\OperationalInterface;
+use PHPMentors\Workflower\Workflow\Operation\OperationRunnerInterface;
+use PHPMentors\Workflower\Workflow\Workflow;
+
+/**
+ * @since Class available since Release 1.2.0
+ */
+class OperationRunnerDelegate implements OperationRunnerInterface
+{
+    /**
+     * @var array
+     */
+    private $operationRunners;
+
+    /**
+     * @param string                   $serviceId
+     * @param OperationRunnerInterface $operationRunner
+     */
+    public function addOperationRunner($serviceId, OperationRunnerInterface $operationRunner)
+    {
+        $this->operationRunners[$serviceId] = $operationRunner;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws OperationRunnerNotFoundException
+     */
+    public function provideParticipant(OperationalInterface $operational, Workflow $workflow)
+    {
+        if (!array_key_exists($operational->getOperation(), $this->operationRunners)) {
+            throw new OperationRunnerNotFoundException(sprintf('The operation runner for the operation "%s" is not found.', $operational->getOperation()));
+        }
+
+        return $this->operationRunners[$operational->getOperation()]->provideParticipant($operational, $workflow);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws OperationRunnerNotFoundException
+     */
+    public function run(OperationalInterface $operational, Workflow $workflow)
+    {
+        if (!array_key_exists($operational->getOperation(), $this->operationRunners)) {
+            throw new OperationRunnerNotFoundException(sprintf('The operation runner for the operation "%s" is not found.', $operational->getOperation()));
+        }
+
+        $this->operationRunners[$operational->getOperation()]->run($operational, $workflow);
+    }
+}

--- a/src/Workflow/Operation/OperationRunnerNotFoundException.php
+++ b/src/Workflow/Operation/OperationRunnerNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp> and contributors,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Operation;
+
+/**
+ * @since Class available since Release 1.2.0
+ */
+class OperationRunnerNotFoundException extends \LogicException
+{
+}

--- a/src/Workflow/Participant/OperationInterface.php
+++ b/src/Workflow/Participant/OperationInterface.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Participant;
+
+/**
+ * @since Interface available since Release 1.2.0
+ */
+interface OperationInterface extends \PHPMentors\DomainKata\Operation\OperationInterface
+{
+}

--- a/src/Workflow/Participant/SecurityParticipantAwareInterface.php
+++ b/src/Workflow/Participant/SecurityParticipantAwareInterface.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Participant;
+
+/**
+ * @since Interface available since Release 1.2.0
+ */
+interface SecurityParticipantAwareInterface extends OperationInterface
+{
+    /**
+     * @param SecurityParticipant $participant
+     */
+    public function setSecurityParticipant(SecurityParticipant $participant);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | BSD-2-Clause

This PR adds the Service Task support.

When a Service Task is reached in the process, the task will be allocated and started automatically, and the associated Symfony service is executed at the `started` state on the work item. And the task will be completed automatically.

Symfony services for this must implement `PHPMentors\Workflower\Workflow\Operation\OperationRunnerInterface` as the following:

```php
<?php
...
use PHPMentors\Workflower\Workflow\Operation\OperationalInterface;
use PHPMentors\Workflower\Workflow\Operation\OperationRunnerInterface;
use PHPMentors\Workflower\Workflow\Workflow;
use PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipant;
use PHPMentors\WorkflowerBundle\Workflow\Participant\SecurityParticipantAwareInterface;

class ...OperationRunner implements OperationRunnerInterface, SecurityParticipantAwareInterface
{
    private $securityParticipant;

    public function setSecurityParticipant(SecurityParticipant $participant)
    {
        $this->securityParticipant = $participant;
    }

    public function provideParticipant(OperationalInterface $operational, Workflow $workflow)
    {
        return $this->securityParticipant;
    }

    public function run(OperationalInterface $operational, Workflow $workflow)
    {
        ...
    }
}
```

And the Symfony service for an operation runner should be tagged as `phpmentors_workflower.operation_runner` with `phpmentors_workflower.security_participant_aware` as the following:

```yaml
    ..._operation_runner:
        ...
        tags:
            - { name: phpmentors_workflower.operation_runner }
            - { name: phpmentors_workflower.security_participant_aware }
```
