### PR TITLE
New minimum required Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
     "require": {
         "php": ">=5.3.9",
         "phpmentors/workflower": "~1.2",
-        "symfony/config": "~2.7",
-        "symfony/dependency-injection": "~2.7",
-        "symfony/finder": "~2.7",
-        "symfony/http-kernel": "~2.7",
-        "symfony/security-core": "~2.7",
-        "symfony/security-bundle": "~2.7"
+        "symfony/config": "~2.8|~3.0",
+        "symfony/dependency-injection": "~2.8|~3.0",
+        "symfony/finder": "~2.8|~3.0",
+        "symfony/http-kernel": "~2.8|~3.0",
+        "symfony/security-core": "~2.8|~3.0",
+        "symfony/security-bundle": "~2.8|~3.0"
     },
     "suggest": {
         "doctrine/orm": "provides transparent serialization/deserialization support for entities with Doctrine ORM",
-        "symfony/doctrine-bridge": ">=2.7.0 provides transparent serialization/deserialization support for entities with Doctrine ORM"
+        "symfony/doctrine-bridge": ">=2.8.0 provides transparent serialization/deserialization support for entities with Doctrine ORM"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | -
| License       | BSD-2-Clause

This will change the the minimum required version of `symfony/*` to `~2.8` or `~3.0`.
