### PR TITLE
Renewed Security Participant with Access Decision Manager

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,15 +1,9 @@
 <?php
-$finder = PhpCsFixer\Finder::create()
+$finder = Symfony\CS\Finder\DefaultFinder::create()
     ->in(__DIR__.'/src')
     ;
 
-return PhpCsFixer\Config::create()
-    ->setRules(array(
-        '@Symfony' => true,
-        'no_useless_return' => false,
-        'blank_line_after_opening_tag' => false,
-        'ordered_imports' => true,
-        'phpdoc_no_empty_return' => false,
-    ))
-    ->setFinder($finder)
+return Symfony\CS\Config\Config::create()
+    ->fixers(array('-empty_return', '-blankline_after_open_tag', 'ordered_use', '-phpdoc_no_empty_return'))
+    ->finder($finder)
     ;

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -36,8 +36,8 @@
       <argument type="collection"/>
     </service>
     <service id="phpmentors_workflower.security_participant" class="%phpmentors_workflower.security_participant.class%">
-      <argument type="service" id="security.access.role_hierarchy_voter"/>
       <argument type="service" id="security.token_storage"/>
+      <argument type="service" id="security.access.decision_manager"/>
     </service>
     <service id="phpmentors_workflower.workflow_serializer" public="false" abstract="true"/>
     <service id="phpmentors_workflower.work_item_context" class="%phpmentors_workflower.work_item_context.class%" shared="false">

--- a/src/Workflow/Participant/SecurityParticipant.php
+++ b/src/Workflow/Participant/SecurityParticipant.php
@@ -36,7 +36,7 @@ class SecurityParticipant implements ParticipantInterface
     /**
      * @var ResourceInterface
      */
-    private $user;
+    private $resource;
 
     /**
      * @param TokenStorageInterface          $tokenStorage
@@ -53,7 +53,7 @@ class SecurityParticipant implements ParticipantInterface
      */
     public function hasRole($role)
     {
-        return $this->accessDecisionManager->decide($this->user === null ? $this->tokenStorage->getToken() : ($this->user instanceof UserInterface ? new UserToken($this->user) : $this->user), array($role));
+        return $this->accessDecisionManager->decide($this->resource === null ? $this->tokenStorage->getToken() : ($this->resource instanceof UserInterface ? new UserToken($this->resource) : $this->resource), array($role));
     }
 
     /**
@@ -63,7 +63,7 @@ class SecurityParticipant implements ParticipantInterface
     {
         assert($resource instanceof UserInterface || $resource instanceof TokenInterface);
 
-        $this->user = $resource;
+        $this->resource = $resource;
     }
 
     /**
@@ -71,7 +71,7 @@ class SecurityParticipant implements ParticipantInterface
      */
     public function getResource()
     {
-        if ($this->user === null) {
+        if ($this->resource === null) {
             $token = $this->tokenStorage->getToken();
             if ($token === null) {
                 return null;
@@ -84,7 +84,7 @@ class SecurityParticipant implements ParticipantInterface
 
             return new UserResource($user);
         } else {
-            return $this->user;
+            return $this->resource;
         }
     }
 

--- a/src/Workflow/Participant/UserResource.php
+++ b/src/Workflow/Participant/UserResource.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Participant;
+
+use PHPMentors\Workflower\Workflow\Resource\ResourceInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+class UserResource implements ResourceInterface
+{
+    /**
+     * @var mixed
+     */
+    private $user;
+
+    /**
+     * @param mixed $user
+     */
+    public function __construct($user)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        if ($this->user instanceof UserInterface) {
+            return $this->user->getUsername();
+        } else {
+            return (string) $this->user;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getId();
+    }
+}

--- a/src/Workflow/Participant/UserToken.php
+++ b/src/Workflow/Participant/UserToken.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Copyright (c) KUBO Atsuhiro <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsWorkflowerBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\WorkflowerBundle\Workflow\Participant;
+
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+class UserToken extends AbstractToken
+{
+    /**
+     * @param UserInterface $user
+     */
+    public function __construct(UserInterface $user)
+    {
+        parent::__construct($user->getRoles());
+
+        $this->setUser($user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCredentials()
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   |
| Fixed tickets | phpmentors-jp/workflower#36
| License       | BSD-2-Clause

This will provide renewed `SecurityParticipant` by using `AccessDecisionManagerInterface` instead of `RoleHierarchyVoter` for checking user permissions.
